### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "demystify"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap 4.5.43",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "demystify-web"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/demystify-web/CHANGELOG.md
+++ b/demystify-web/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.0...demystify-web-v0.1.1) - 2025-08-08
+
+### Other
+
+- Update Rustsat version

--- a/demystify-web/Cargo.toml
+++ b/demystify-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demystify-web"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "A web front end to demystify, a constraint solving tool for explaining puzzles"
 license = "MPL-2.0"
@@ -23,7 +23,7 @@ serde_json = "1"
 serde = "1"
 anyhow = "1"
 tempfile = "3"
-demystify = { path = "../demystify", version = "0.1.0" }
+demystify = { path = "../demystify", version = "0.1.1" }
 uuid = "1"
 
 rustsat = { version = "0.7", features=["ipasir-display"] }

--- a/demystify/CHANGELOG.md
+++ b/demystify/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.1.0...demystify-v0.1.1) - 2025-08-08
+
+### Other
+
+- Update Rustsat version

--- a/demystify/Cargo.toml
+++ b/demystify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demystify"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "A constraint solving tool for explaining puzzles"
 license = "MPL-2.0"


### PR DESCRIPTION



## 🤖 New release

* `demystify`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `demystify-web`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `demystify`

<blockquote>

## [0.1.1](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.1.0...demystify-v0.1.1) - 2025-08-08

### Other

- Update Rustsat version
</blockquote>

## `demystify-web`

<blockquote>

## [0.1.1](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.0...demystify-web-v0.1.1) - 2025-08-08

### Other

- Update Rustsat version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).