### PR TITLE
chore: release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "demystify"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap 4.5.43",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "demystify-web"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/demystify-web/CHANGELOG.md
+++ b/demystify-web/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.2...demystify-web-v0.1.3) - 2025-08-10
+
+### Other
+
+- updated the following local packages: demystify
+
 ## [0.1.2](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.1...demystify-web-v0.1.2) - 2025-08-09
 
 ### Other

--- a/demystify-web/Cargo.toml
+++ b/demystify-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demystify-web"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "A web front end to demystify, a constraint solving tool for explaining puzzles"
 license = "MPL-2.0"
@@ -23,7 +23,7 @@ serde_json = "1"
 serde = "1"
 anyhow = "1"
 tempfile = "3"
-demystify = { path = "../demystify", version = "0.1.2" }
+demystify = { path = "../demystify", version = "0.1.3" }
 uuid = "1"
 
 rustsat = { version = "0.7", features=["ipasir-display"] }

--- a/demystify/CHANGELOG.md
+++ b/demystify/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.1.2...demystify-v0.1.3) - 2025-08-10
+
+### Other
+
+- Add a better error message
+
 ## [0.1.2](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.1.1...demystify-v0.1.2) - 2025-08-09
 
 ### Other

--- a/demystify/Cargo.toml
+++ b/demystify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demystify"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "A constraint solving tool for explaining puzzles"
 license = "MPL-2.0"

--- a/demystify/src/problem/util/exec.rs
+++ b/demystify/src/problem/util/exec.rs
@@ -74,9 +74,11 @@ fn detect_run_method() -> RunMethod {
     }
 
     if which("docker").is_ok() {
-        eprintln!("Using docker");
+        eprintln!("Using docker. Make sure docker is installed!");
         return RunMethod::Docker;
     }
+
+    eprintln!("Cannot find conjure, or podman or docker (so I can install them). The easist fix is to install docker or podman!");
 
     // Default to native if we couldn't detect anything
     // This might fail later, but at least we tried


### PR DESCRIPTION



## 🤖 New release

* `demystify`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `demystify-web`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `demystify`

<blockquote>

## [0.1.3](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.1.2...demystify-v0.1.3) - 2025-08-10

### Other

- Add a better error message
</blockquote>

## `demystify-web`

<blockquote>

## [0.1.3](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.2...demystify-web-v0.1.3) - 2025-08-10

### Other

- updated the following local packages: demystify
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).