### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "demystify"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "demystify-web"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/demystify-lua/Cargo.toml
+++ b/demystify-lua/Cargo.toml
@@ -10,6 +10,6 @@ repository = "https://github.com/stacs-cp/demystify-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-demystify = { path = "../demystify", version = "0.1.3" }
+demystify = { path = "../demystify", version = "0.2.0" }
 mlua = { version = "0.11", features = ["luajit", "module"] }
 anyhow = "1.0"

--- a/demystify-web/CHANGELOG.md
+++ b/demystify-web/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.3...demystify-web-v0.1.4) - 2026-04-04
+
+### Added
+
+- *(web)* add Minesweeper example with hidden-information reveal
+- *(akari)* add wall_below decoration for thick-border black cell rendering
+- *(nonogram)* add Duck and Heart test puzzles, register web demo
+- *(mosaic)* add Mosaic (Minesweeper) puzzle model and web demo
+- *(akari)* add Akari (Light Up) puzzle model and examples
+- *(web)* add puzzle overview panel with $#INFO and constraint classes
+- *(puzzles)* add Kakurasu/Skyscrapers/XSums web examples, fix Kakurasu labels
+- *(svg)* add thermometer, futoshiki, and killer sudoku rendering
+
+### Fixed
+
+- *(planner)* refresh shows current state; deduction renders post-deduction grid
+- *(akari)* replace under-constrained 5x5 instance with uniquely solvable one
+- *(svg)* add clue_in_corner decoration for Mosaic-style puzzles
+- *(x-sums)* remove $#DESC from ctc param (causes parse error)
+- *(x-sums)* remove dead commented directives, fix template syntax, add easy demo param
+- *(thermometer)* correct grid variable to row-major indexing
+
+### Other
+
+- replace NamedTempFile/tempdir with prefixed tempdir_in(".") to avoid sandbox write restrictions
+- fmt, update package dependancies
+- broad codebase cleanup and improvements
+
 ## [0.1.3](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.2...demystify-web-v0.1.3) - 2025-08-10
 
 ### Other

--- a/demystify-web/Cargo.toml
+++ b/demystify-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demystify-web"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "A web front end to demystify, a constraint solving tool for explaining puzzles"
 license = "MPL-2.0"
@@ -22,7 +22,7 @@ serde_json = "1"
 serde = "1"
 anyhow = "1"
 tempfile = "3"
-demystify = { path = "../demystify", version = "0.1.3" }
+demystify = { path = "../demystify", version = "0.2.0" }
 uuid = "1"
 
 rustsat = { version = "0.7", features=["ipasir-display"] }

--- a/demystify/CHANGELOG.md
+++ b/demystify/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.1.3...demystify-v0.2.0) - 2026-04-04
+
+### Added
+
+- *(planner)* add unsolved_vars_after_solve to PuzzlePlanner
+- *(solver)* add find_one mode to narrow MUS search within each batch
+- *(stats)* per-SAT-call time and conflict bucket tables
+- *(planner)* add max_steps field to PlannerConfig
+- *(satcore)* add CaDiCaL backend alongside glucose
+- *(stats)* per-function MUS timing table with time buckets
+- *(bench)* miracle sudoku step-sweep benchmarks
+- *(stats)* add global MUS statistics collector
+- *(akari)* add wall_below decoration for thick-border black cell rendering
+- *(svg)* composable decorations via \$#DEC, show blocked cells in difficulty view
+- *(mosaic)* add Mosaic (Minesweeper) puzzle model and web demo
+- *(bench)* add Criterion benchmarking suite for solve performance
+- *(web)* add puzzle overview panel with $#INFO and constraint classes
+- *(svg)* add thermometer, futoshiki, and killer sudoku rendering
+
+### Fixed
+
+- *(stats)* use iterator enumerate to satisfy clippy needless_range_loop
+- *(stats)* replace unbounded Vec accumulation with O(1) pre-aggregated buckets
+- *(planner)* refresh shows current state; deduction renders post-deduction grid
+- *(planner)* show grid with message instead of bare "No MUS" text
+- *(svg)* add clue_in_corner decoration for Mosaic-style puzzles
+- *(loopy)* rewrite to avoid conjure_aux and function types
+- *(web)* always-open overview panel and fix constraint cell hover
+- *(svg)* draw futoshiki arrows as SVG chevrons instead of text
+
+### Other
+
+- Run cargo fmt
+- Fix leaving temp files around
+- replace NamedTempFile/tempdir with prefixed tempdir_in(".") to avoid sandbox write restrictions
+- fmt, update package dependancies
+- Fix off-by-one error in test
+- broad codebase cleanup and improvements
+- Fix bug in cake MUS
+- *(solver)* remove upfront size-0 SAT call in get_var_mus_size_1
+- *(planner)* add cross-step MUS cache to PuzzlePlanner
+- add comprehensive documentation with examples
+- Handle empty INFO
+- Add missing method
+- Add constraint_roots
+- Add lua library
+- Add 'INFO to store information about models
+- Make to_json_map more generic
+- Add to_json_map, nicer method for handing PuzVar assignments
+- Do some clippy
+- Add method to turn PuzVar assignments into nice JSON output
+
 ## [0.1.3](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.1.2...demystify-v0.1.3) - 2025-08-10
 
 ### Other

--- a/demystify/Cargo.toml
+++ b/demystify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demystify"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 description = "A constraint solving tool for explaining puzzles"
 license = "MPL-2.0"


### PR DESCRIPTION



## 🤖 New release

* `demystify`: 0.1.3 -> 0.2.0 (⚠ API breaking changes)
* `demystify-web`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

### ⚠ `demystify` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PlannerConfig.max_steps in /tmp/.tmpVJnU1e/demystify-rs/demystify/src/problem/planner.rs:31
  field Puzzle.thermometers in /tmp/.tmpVJnU1e/demystify-rs/demystify/src/json/mod.rs:32
  field Puzzle.less_than in /tmp/.tmpVJnU1e/demystify-rs/demystify/src/json/mod.rs:34
  field Puzzle.cage_sums in /tmp/.tmpVJnU1e/demystify-rs/demystify/src/json/mod.rs:36
  field Puzzle.info in /tmp/.tmpVJnU1e/demystify-rs/demystify/src/json/mod.rs:38
  field Puzzle.constraint_classes in /tmp/.tmpVJnU1e/demystify-rs/demystify/src/json/mod.rs:41
  field Puzzle.decorations in /tmp/.tmpVJnU1e/demystify-rs/demystify/src/json/mod.rs:44
  field MusConfig.find_one in /tmp/.tmpVJnU1e/demystify-rs/demystify/src/problem/solver.rs:46
  field State.blocked_cells in /tmp/.tmpVJnU1e/demystify-rs/demystify/src/json/mod.rs:301

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  demystify::problem::parse::PuzzleParse::new_from_eprime now takes 7 parameters instead of 6, in /tmp/.tmpVJnU1e/demystify-rs/demystify/src/problem/parse.rs:328
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `demystify`

<blockquote>

## [0.2.0](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.1.3...demystify-v0.2.0) - 2026-04-04

### Added

- *(planner)* add unsolved_vars_after_solve to PuzzlePlanner
- *(solver)* add find_one mode to narrow MUS search within each batch
- *(stats)* per-SAT-call time and conflict bucket tables
- *(planner)* add max_steps field to PlannerConfig
- *(satcore)* add CaDiCaL backend alongside glucose
- *(stats)* per-function MUS timing table with time buckets
- *(bench)* miracle sudoku step-sweep benchmarks
- *(stats)* add global MUS statistics collector
- *(akari)* add wall_below decoration for thick-border black cell rendering
- *(svg)* composable decorations via \$#DEC, show blocked cells in difficulty view
- *(mosaic)* add Mosaic (Minesweeper) puzzle model and web demo
- *(bench)* add Criterion benchmarking suite for solve performance
- *(web)* add puzzle overview panel with $#INFO and constraint classes
- *(svg)* add thermometer, futoshiki, and killer sudoku rendering

### Fixed

- *(stats)* use iterator enumerate to satisfy clippy needless_range_loop
- *(stats)* replace unbounded Vec accumulation with O(1) pre-aggregated buckets
- *(planner)* refresh shows current state; deduction renders post-deduction grid
- *(planner)* show grid with message instead of bare "No MUS" text
- *(svg)* add clue_in_corner decoration for Mosaic-style puzzles
- *(loopy)* rewrite to avoid conjure_aux and function types
- *(web)* always-open overview panel and fix constraint cell hover
- *(svg)* draw futoshiki arrows as SVG chevrons instead of text

### Other

- Run cargo fmt
- Fix leaving temp files around
- replace NamedTempFile/tempdir with prefixed tempdir_in(".") to avoid sandbox write restrictions
- fmt, update package dependancies
- Fix off-by-one error in test
- broad codebase cleanup and improvements
- Fix bug in cake MUS
- *(solver)* remove upfront size-0 SAT call in get_var_mus_size_1
- *(planner)* add cross-step MUS cache to PuzzlePlanner
- add comprehensive documentation with examples
- Handle empty INFO
- Add missing method
- Add constraint_roots
- Add lua library
- Add 'INFO to store information about models
- Make to_json_map more generic
- Add to_json_map, nicer method for handing PuzVar assignments
- Do some clippy
- Add method to turn PuzVar assignments into nice JSON output
</blockquote>

## `demystify-web`

<blockquote>

## [0.1.4](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.3...demystify-web-v0.1.4) - 2026-04-04

### Added

- *(web)* add Minesweeper example with hidden-information reveal
- *(akari)* add wall_below decoration for thick-border black cell rendering
- *(nonogram)* add Duck and Heart test puzzles, register web demo
- *(mosaic)* add Mosaic (Minesweeper) puzzle model and web demo
- *(akari)* add Akari (Light Up) puzzle model and examples
- *(web)* add puzzle overview panel with $#INFO and constraint classes
- *(puzzles)* add Kakurasu/Skyscrapers/XSums web examples, fix Kakurasu labels
- *(svg)* add thermometer, futoshiki, and killer sudoku rendering

### Fixed

- *(planner)* refresh shows current state; deduction renders post-deduction grid
- *(akari)* replace under-constrained 5x5 instance with uniquely solvable one
- *(svg)* add clue_in_corner decoration for Mosaic-style puzzles
- *(x-sums)* remove $#DESC from ctc param (causes parse error)
- *(x-sums)* remove dead commented directives, fix template syntax, add easy demo param
- *(thermometer)* correct grid variable to row-major indexing

### Other

- replace NamedTempFile/tempdir with prefixed tempdir_in(".") to avoid sandbox write restrictions
- fmt, update package dependancies
- broad codebase cleanup and improvements
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).