### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "demystify"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "demystify-web"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/demystify-lua/Cargo.toml
+++ b/demystify-lua/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-demystify = { path = "../demystify", version = "0.3.0" }
+demystify = { path = "../demystify", version = "0.3.1" }
 demystify-builder = { path = "../demystify-builder", version = "0.1.0" }
 mlua = { version = "0.11", features = ["luajit", "module"] }
 anyhow = "1.0"

--- a/demystify-wasm/Cargo.toml
+++ b/demystify-wasm/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-demystify = { path = "../demystify", version = "0.3.0" }
+demystify = { path = "../demystify", version = "0.3.1" }
 demystify-builder = { path = "../demystify-builder", version = "0.1.0" }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"

--- a/demystify-web/CHANGELOG.md
+++ b/demystify-web/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.4...demystify-web-v0.2.0) - 2026-06-07
+
+### Other
+
+- Fix doc errors and tidy README prose
+- Release demystify 0.3.0
+- Fix README errors, declare MSRV, mark demystify-lua unpublishable
+- Delete orphan inspector templates and their dead CSS section
+- Share strategy-DB loading across binaries
+- fix coldown direction in thermometer game level
+- Merge branch 'demystify-game'
+- Add hide_untouched_candidates option to JSON renderer
+- Extend $#SHOW with renderer roles, drop magic-name fallbacks
+- Add $#SHOW <var> <role> directive for renderer variable selection
+- Move SessionSnapshot from demystify-web to demystify::snapshot
+- Add named-strategy recognition for MUSes
+- Add session export/import for sharing solve states
+- Bundle htmx, D3.js, and fonts for fully offline operation
+- Add step history with undo via PuzzlePlanner forking
+- Add solve tree web page using session puzzle
+- Add 'explore' mode to the GUI
+- Update gui
+
 ## [0.1.4](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.3...demystify-web-v0.1.4) - 2026-04-04
 
 ### Added

--- a/demystify-web/Cargo.toml
+++ b/demystify-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demystify-web"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.94.1"
 description = "A web front end to demystify, a constraint solving tool for explaining puzzles"
@@ -23,7 +23,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 anyhow = "1"
 tempfile = "3"
-demystify = { path = "../demystify", version = "0.3.0" }
+demystify = { path = "../demystify", version = "0.3.1" }
 uuid = "1"
 tera = { version = "1.19", default-features = false }
 

--- a/demystify/CHANGELOG.md
+++ b/demystify/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.3.0...demystify-v0.3.1) - 2026-06-07
+
+### Other
+
+- Fix doc errors and tidy README prose
+- Replace crate-wide allow(dead_code) with scoped exemptions
+
 ## [0.3.0](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.2.0...demystify-v0.3.0) - 2026-06-05
 
 ### Added

--- a/demystify/Cargo.toml
+++ b/demystify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demystify"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.94.1"
 description = "A constraint solving tool for explaining puzzles"


### PR DESCRIPTION



## 🤖 New release

* `demystify`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `demystify-web`: 0.1.4 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `demystify-web` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_missing.ron

Failed in:
  function demystify_web::wrap::get_example_names, previously in file /tmp/.tmpiZpX0f/demystify-web/src/wrap/mod.rs:333
  function demystify_web::wrap::load_example, previously in file /tmp/.tmpiZpX0f/demystify-web/src/wrap/mod.rs:306
  function demystify_web::wrap::click_literal, previously in file /tmp/.tmpiZpX0f/demystify-web/src/wrap/mod.rs:160
  function demystify_web::wrap::refresh, previously in file /tmp/.tmpiZpX0f/demystify-web/src/wrap/mod.rs:150
  function demystify_web::wrap::get_difficulties, previously in file /tmp/.tmpiZpX0f/demystify-web/src/wrap/mod.rs:140
  function demystify_web::wrap::best_next_step, previously in file /tmp/.tmpiZpX0f/demystify-web/src/wrap/mod.rs:124

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  demystify_web::wrap::submit_example now takes 3 parameters instead of 2, in /tmp/.tmpPXpkwz/demystify-rs/demystify-web/src/wrap/mod.rs:835
  demystify_web::wrap::upload_files now takes 3 parameters instead of 2, in /tmp/.tmpPXpkwz/demystify-rs/demystify-web/src/wrap/mod.rs:688
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `demystify`

<blockquote>

## [0.3.1](https://github.com/stacs-cp/demystify-rs/compare/demystify-v0.3.0...demystify-v0.3.1) - 2026-06-07

### Other

- Fix doc errors and tidy README prose
- Replace crate-wide allow(dead_code) with scoped exemptions
</blockquote>

## `demystify-web`

<blockquote>

## [0.2.0](https://github.com/stacs-cp/demystify-rs/compare/demystify-web-v0.1.4...demystify-web-v0.2.0) - 2026-06-07

### Other

- Fix doc errors and tidy README prose
- Release demystify 0.3.0
- Fix README errors, declare MSRV, mark demystify-lua unpublishable
- Delete orphan inspector templates and their dead CSS section
- Share strategy-DB loading across binaries
- fix coldown direction in thermometer game level
- Merge branch 'demystify-game'
- Add hide_untouched_candidates option to JSON renderer
- Extend $#SHOW with renderer roles, drop magic-name fallbacks
- Add $#SHOW <var> <role> directive for renderer variable selection
- Move SessionSnapshot from demystify-web to demystify::snapshot
- Add named-strategy recognition for MUSes
- Add session export/import for sharing solve states
- Bundle htmx, D3.js, and fonts for fully offline operation
- Add step history with undo via PuzzlePlanner forking
- Add solve tree web page using session puzzle
- Add 'explore' mode to the GUI
- Update gui
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).